### PR TITLE
Links: update cheatsheets URL

### DIFF
--- a/jekyll_content/_data/links.yaml
+++ b/jekyll_content/_data/links.yaml
@@ -32,7 +32,7 @@ plantuml:
   url: http://plantuml.com/
   description: Markdown to UML Diagramm
 cheatsheets:
-  url: http://ricostacruz.com/cheatsheets/
+  url: https://devhints.io/
   description: cheatsheets collection
 microbadger:
   url: https://microbadger.com


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)
